### PR TITLE
운영환경 properties 수정

### DIFF
--- a/backend/WWMeet_backend/src/main/resources/application-prod.properties
+++ b/backend/WWMeet_backend/src/main/resources/application-prod.properties
@@ -5,9 +5,9 @@ spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.ddl-auto=update
 
-spring.datasource.url=jdbc:mysql://database-wwmeet.chm6ujmls3ye.ap-northeast-2.rds.amazonaws.com:3306/WWMeet_DB
-spring.datasource.username=admin
-spring.datasource.password=adminadmin
+spring.datasource.url=${{ secret.DB_URL }}
+spring.datasource.usernam=${{ secret.DB_USERNAME }}
+spring.datasource.password=${{ secret.DB_PASSWORD }}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 logging.level.org.hibernate=info


### PR DESCRIPTION
운영 환경에서 사용될 properties를 생성하였다
aws rds관련 설정은 github secret키를 사용하였다.

## 목적
운영 환경 aws rds 설정 정보를 숨기기 위함
## 변경점
기존의 입력한 코드를 Github secret을 사용하도록 변경
## 특이사항

## 이슈 #48 
