### PR TITLE
Feat: 스프링 부트 3.15로 이관, swagger 적용

### DIFF
--- a/backend/WWMeet_backend/build.gradle
+++ b/backend/WWMeet_backend/build.gradle
@@ -1,14 +1,14 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '2.7.14'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id 'org.springframework.boot' version '3.1.5'
+	id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+	sourceCompatibility = '17'
 }
 
 configurations {
@@ -24,11 +24,14 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.h2database:h2:2.1.214'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
+
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.3'
 }
 
 tasks.named('test') {

--- a/backend/WWMeet_backend/src/main/resources/application-local.properties
+++ b/backend/WWMeet_backend/src/main/resources/application-local.properties
@@ -2,7 +2,6 @@ server.address=localhost
 server.port=8080
 
 spring.jpa.database=mysql
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.ddl-auto=update
 
 spring.datasource.url=jdbc:mysql://localhost:3306/ww_meet

--- a/backend/WWMeet_backend/src/main/resources/application-prod.properties
+++ b/backend/WWMeet_backend/src/main/resources/application-prod.properties
@@ -2,7 +2,6 @@ server.address=localhost
 server.port=8080
 
 spring.jpa.database=mysql
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.ddl-auto=update
 
 spring.datasource.url=${{ secret.DB_URL }}

--- a/backend/WWMeet_backend/src/main/resources/application.properties
+++ b/backend/WWMeet_backend/src/main/resources/application.properties
@@ -4,7 +4,6 @@ server.address=localhost
 server.port=8080
 
 spring.jpa.database=mysql
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.ddl-auto=update
 
 spring.datasource.url=jdbc:mysql://localhost:3306/ww_meet


### PR DESCRIPTION
swagger 적용시 필요해서 스프링 부트 2.7 -> 3.15로 이관
swagger 의존성 추가

## 목적
swagger 적용 후 api 테스트

## 변경점
swagger 의존성 추가
swagger 적용에 필요해서 스프링 부트 2.7 -> 3.15로 이관

## 특이사항
mysqlinnodb 설정 옵션이 에러가 떠서 삭제하여 해결

## 이슈
