### PR TITLE
약속 전제, 단건 조회 로직 수정

### DIFF
--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
@@ -7,11 +7,8 @@ import com.example.wwmeet_backend.domain.appointment.dto.response.FindAppointmen
 import com.example.wwmeet_backend.domain.appointment.dto.response.FindAppointmentResponse;
 import com.example.wwmeet_backend.domain.appointment.service.AppointmentService;
 import com.example.wwmeet_backend.domain.participant.service.ParticipantService;
-import com.example.wwmeet_backend.global.util.CurrentMemberService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
@@ -46,9 +46,9 @@ public class AppointmentController {
         return appointmentService.findAllAppointment();
     }
 
-    @GetMapping("/{id}/{name}/vote-status")
+    @GetMapping("/{id}/{participantName}/vote-status")
     public boolean getParticipantWithVoteStatus(
-        @PathVariable("id") Long appointmentId, @PathVariable("name") String participantName) {
+        @PathVariable("id") Long appointmentId, @PathVariable String participantName) {
         System.out.println(participantName);
         return appointmentService.getParticipantVoteStatus(appointmentId, participantName);
     }

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/controller/AppointmentController.java
@@ -10,6 +10,7 @@ import com.example.wwmeet_backend.domain.participant.service.ParticipantService;
 import com.example.wwmeet_backend.global.util.CurrentMemberService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,13 +27,15 @@ public class AppointmentController {
 
     private final AppointmentService appointmentService;
     private final ParticipantService participantService;
-    private final CurrentMemberService currentMemberService;
 
     @PostMapping
     public Long saveAppointment(@RequestBody SaveAppointmentRequest saveAppointmentRequest) {
         Long savedAppointmentId = appointmentService.saveAppointment(saveAppointmentRequest);
+
         participantService.addParticipantByAppointmentId(
-            saveAppointmentRequest.getParticipantName(), savedAppointmentId);
+            saveAppointmentRequest.getParticipantName(), savedAppointmentId
+        );
+
         return savedAppointmentId;
     }
 
@@ -43,7 +46,7 @@ public class AppointmentController {
 
     @GetMapping
     public List<FindAppointmentListResponse> findAllAppointment() {
-        return appointmentService.findAllAppointment(currentMemberService.getCurrentMember());
+        return appointmentService.findAllAppointment();
     }
 
     @GetMapping("/{id}/{name}/vote-status")

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/domain/Appointment.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/domain/Appointment.java
@@ -14,8 +14,15 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Appointment {
 
     @Id
@@ -44,50 +51,20 @@ public class Appointment {
     @OneToMany(mappedBy = "appointment")
     private final List<Participant> participantList = new ArrayList<>();
 
-    protected Appointment() {
-    }
-
+    @Builder
     private Appointment(Long id, String name, String place,
-        String identificationCode, int participantNum, LocalDateTime voteDeadline) {
+        String identificationCode, int participantNum, LocalDateTime voteDeadline, Member member) {
         this.id = id;
         this.name = name;
         this.place = place;
         this.identificationCode = identificationCode;
         this.participantNum = participantNum;
         this.voteDeadline = voteDeadline;
+        this.member = member;
     }
 
-    public static Appointment of(Long id, String appointmentName, String appointmentPlace,
-        String identificationCode, int participantNum, LocalDateTime voteDeadline) {
-        return new Appointment(id, appointmentName, appointmentPlace, identificationCode,
-            participantNum, voteDeadline);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getPlace() {
-        return place;
-    }
-
-    public String getIdentificationCode() {
-        return identificationCode;
-    }
-
-    public int getParticipantNum() {
-        return participantNum;
-    }
-
-    public LocalDateTime getVoteDeadline() {
-        return voteDeadline;
-    }
-
-    public List<Participant> getParticipantList() {
-        return participantList;
+    public void createIdentificationCode() {
+        UUID identificationCodeUUID = UUID.randomUUID();
+        this.identificationCode = identificationCodeUUID.toString().substring(0, 15);
     }
 }

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/request/SaveAppointmentRequest.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/request/SaveAppointmentRequest.java
@@ -2,6 +2,7 @@ package com.example.wwmeet_backend.domain.appointment.dto.request;
 
 
 import com.example.wwmeet_backend.domain.appointment.domain.Appointment;
+import com.example.wwmeet_backend.domain.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -11,8 +12,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
-@Builder
 public class SaveAppointmentRequest {
 
     private String appointmentName;
@@ -21,18 +20,14 @@ public class SaveAppointmentRequest {
     private String participantName;
     private LocalDateTime voteDeadline;
 
-    public SaveAppointmentRequest() {
-    }
-
-    public Appointment toEntity() {
-        String appointmentCode = createIdentificationCode();
-        return Appointment.of(null, appointmentName, appointmentPlace, appointmentCode,
-            participantNum, voteDeadline);
-    }
-
-    private String createIdentificationCode() {
-        UUID identificationCodeUUID = UUID.randomUUID();
-        String identificationCode = identificationCodeUUID.toString().substring(0, 15);
-        return identificationCode;
+    @Builder
+    public SaveAppointmentRequest(String appointmentName, String appointmentPlace,
+        int participantNum,
+        String participantName, LocalDateTime voteDeadline) {
+        this.appointmentName = appointmentName;
+        this.appointmentPlace = appointmentPlace;
+        this.participantNum = participantNum;
+        this.participantName = participantName;
+        this.voteDeadline = voteDeadline;
     }
 }

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/request/SaveAppointmentRequest.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/request/SaveAppointmentRequest.java
@@ -1,17 +1,15 @@
 package com.example.wwmeet_backend.domain.appointment.dto.request;
 
 
-import com.example.wwmeet_backend.domain.appointment.domain.Appointment;
-import com.example.wwmeet_backend.domain.member.domain.Member;
 import java.time.LocalDateTime;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class SaveAppointmentRequest {
 
     private String appointmentName;

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/response/FindAppointmentListResponse.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/dto/response/FindAppointmentListResponse.java
@@ -14,14 +14,16 @@ public class FindAppointmentListResponse {
     private LocalDateTime voteDeadline;
     private boolean voteFinish;
     private String appointmentDate;
+    private String participantName;
 
     @Builder
     public FindAppointmentListResponse(Long id, String appointmentName, LocalDateTime voteDeadline,
-        boolean voteFinish, String appointmentDate) {
+        boolean voteFinish, String appointmentDate, String participantName) {
         this.id = id;
         this.appointmentName = appointmentName;
         this.voteDeadline = voteDeadline;
         this.voteFinish = voteFinish;
         this.appointmentDate = appointmentDate;
+        this.participantName = participantName;
     }
 }

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
@@ -61,25 +61,37 @@ public class AppointmentService {
 
     public List<FindAppointmentListResponse> findAllAppointment() {
         Long memberId = currentMemberService.getCurrentMember().getId();
-
         List<Appointment> foundAppointmentList =
             appointmentRepository.findAppointmentByMemberId(memberId);
 
         List<FindAppointmentListResponse> responseList = new ArrayList<>();
-        for (Appointment appointment : foundAppointmentList) {
-            AppointmentDate appointmentDate = appointmentDateRepository.findByAppointmentId(
-                appointment.getId()).orElseThrow(RuntimeException::new);
 
+        for (Appointment appointment : foundAppointmentList) {
+            FindAppointmentListResponse response = new FindAppointmentListResponse();
             if(checkVoteState(appointment)){
-                responseList.add(
-                    new FindAppointmentListResponse(appointment.getId(), appointment.getName(),
-                        appointment.getVoteDeadline(), checkVoteState(appointment),
-                        appointmentDate.toString())
-                );
+                AppointmentDate appointmentDate = appointmentDateRepository.findByAppointmentId(
+                    appointment.getId()).orElseThrow(RuntimeException::new);
+
+                response = FindAppointmentListResponse.builder()
+                    .id(appointment.getId())
+                    .appointmentName(appointment.getName())
+                    .voteFinish(true)
+                    .appointmentDate(appointmentDate.toString())
+                    .build();
+
+                continue;
+            } else {
+                response = FindAppointmentListResponse.builder()
+                    .id(appointment.getId())
+                    .appointmentName(appointment.getName())
+                    .voteDeadline(appointment.getVoteDeadline())
+                    .voteFinish(false)
+                    .build();
             }
+            responseList.add(response);
         }
 
-        return new ArrayList<>();
+        return responseList;
     }
 
     public boolean getParticipantVoteStatus(Long appointmentId, String participantName) {

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
@@ -67,7 +67,9 @@ public class AppointmentService {
         List<FindAppointmentListResponse> responseList = new ArrayList<>();
 
         for (Appointment appointment : foundAppointmentList) {
-            FindAppointmentListResponse response = new FindAppointmentListResponse();
+            Participant participant = participantRepository.findByAppointmentIdAndMemberId(
+                    appointment.getId(), memberId).orElseThrow(RuntimeException::new);
+            FindAppointmentListResponse response;
             if(checkVoteState(appointment)){
                 AppointmentDate appointmentDate = appointmentDateRepository.findByAppointmentId(
                     appointment.getId()).orElseThrow(RuntimeException::new);
@@ -77,15 +79,15 @@ public class AppointmentService {
                     .appointmentName(appointment.getName())
                     .voteFinish(true)
                     .appointmentDate(appointmentDate.toString())
+                    .participantName(participant.getParticipantName())
                     .build();
-
-                continue;
             } else {
                 response = FindAppointmentListResponse.builder()
                     .id(appointment.getId())
                     .appointmentName(appointment.getName())
                     .voteDeadline(appointment.getVoteDeadline())
                     .voteFinish(false)
+                    .participantName(participant.getParticipantName())
                     .build();
             }
             responseList.add(response);

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/service/AppointmentService.java
@@ -8,6 +8,7 @@ import com.example.wwmeet_backend.domain.appointment.dto.response.DateRangeRespo
 import com.example.wwmeet_backend.domain.appointment.dto.response.FindAppointmentListResponse;
 import com.example.wwmeet_backend.domain.appointment.dto.response.FindAppointmentResponse;
 import com.example.wwmeet_backend.domain.appointment.repository.AppointmentRepository;
+import com.example.wwmeet_backend.domain.appointment.util.AppointmentDtoMapper;
 import com.example.wwmeet_backend.domain.appointmentDate.domain.AppointmentDate;
 import com.example.wwmeet_backend.domain.appointmentDate.repository.AppointmentDateRepository;
 import com.example.wwmeet_backend.domain.member.domain.Member;
@@ -15,6 +16,7 @@ import com.example.wwmeet_backend.domain.participant.domain.Participant;
 import com.example.wwmeet_backend.domain.participant.repository.ParticipantRepository;
 import com.example.wwmeet_backend.domain.vote.domain.Vote;
 import com.example.wwmeet_backend.domain.vote.repository.VoteRepository;
+import com.example.wwmeet_backend.global.util.CurrentMemberService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -32,11 +34,15 @@ public class AppointmentService {
     private final AppointmentDateRepository appointmentDateRepository;
     private final ParticipantRepository participantRepository;
     private final VoteRepository voteRepository;
+    private final CurrentMemberService currentMemberService;
 
     @Transactional
     public Long saveAppointment(SaveAppointmentRequest saveAppointmentRequest) {
+        Member currentMember = currentMemberService.getCurrentMember();
+
         Appointment savedAppointment = appointmentRepository.save(
-            saveAppointmentRequest.toEntity());
+            AppointmentDtoMapper.toEntity(saveAppointmentRequest, currentMember));
+
         return savedAppointment.getId();
     }
 
@@ -53,8 +59,8 @@ public class AppointmentService {
             .build();
     }
 
-    public List<FindAppointmentListResponse> findAllAppointment(Member member) {
-        Long memberId = member.getId();
+    public List<FindAppointmentListResponse> findAllAppointment() {
+        Long memberId = currentMemberService.getCurrentMember().getId();
 
         List<Appointment> foundAppointmentList =
             appointmentRepository.findAppointmentByMemberId(memberId);

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/util/AppointmentDtoMapper.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/appointment/util/AppointmentDtoMapper.java
@@ -1,0 +1,24 @@
+package com.example.wwmeet_backend.domain.appointment.util;
+
+import com.example.wwmeet_backend.domain.appointment.domain.Appointment;
+import com.example.wwmeet_backend.domain.appointment.dto.request.SaveAppointmentRequest;
+import com.example.wwmeet_backend.domain.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AppointmentDtoMapper {
+    public static Appointment toEntity(SaveAppointmentRequest request, Member member) {
+        Appointment appointment = Appointment.builder()
+            .name(request.getAppointmentName())
+            .place(request.getAppointmentPlace())
+            .participantNum(request.getParticipantNum())
+            .voteDeadline(request.getVoteDeadline())
+            .member(member)
+            .build();
+
+        appointment.createIdentificationCode();
+
+        return appointment;
+    }
+}

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/participant/domain/Participant.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/participant/domain/Participant.java
@@ -13,10 +13,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant {
 
     @Id
@@ -36,16 +40,11 @@ public class Participant {
     @OneToMany(mappedBy = "participant", fetch = FetchType.LAZY)
     private final List<Vote> voteList = new ArrayList<>();
 
-    protected Participant() {
-    }
-
-    private Participant(Appointment appointment, String participantName) {
+    @Builder
+    private Participant(Long id, Appointment appointment, String participantName, Member member) {
+        this.id = id;
         this.appointment = appointment;
         this.participantName = participantName;
+        this.member = member;
     }
-
-    public static Participant of(Appointment appointment, String participantName) {
-        return new Participant(appointment, participantName);
-    }
-
 }

--- a/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/participant/util/ParticipantDtoMapper.java
+++ b/backend/WWMeet_backend/src/main/java/com/example/wwmeet_backend/domain/participant/util/ParticipantDtoMapper.java
@@ -1,0 +1,18 @@
+package com.example.wwmeet_backend.domain.participant.util;
+
+import com.example.wwmeet_backend.domain.appointment.domain.Appointment;
+import com.example.wwmeet_backend.domain.member.domain.Member;
+import com.example.wwmeet_backend.domain.participant.domain.Participant;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ParticipantDtoMapper {
+    public static Participant toEntity(String name, Appointment appointment, Member member) {
+        return Participant.builder()
+            .appointment(appointment)
+            .participantName(name)
+            .member(member)
+            .build();
+    }
+}

--- a/frontend/app/src/main/java/com/example/wwmeet_android/MainActivity.java
+++ b/frontend/app/src/main/java/com/example/wwmeet_android/MainActivity.java
@@ -75,7 +75,8 @@ public class MainActivity extends AppCompatActivity {
                 }else{
                     // 전체 투표 끝나기 전
                     Call<Boolean> voteStatusCall = retrofitService.getVoteStatusOfParticipant(
-                            appointmentList.get(position).getId(), appointmentList.get(position).getName());
+                            appointmentList.get(position).getId(), appointmentList.get(position).getParticipantName());
+
                     voteStatusCall.enqueue(new Callback<Boolean>() {
                         @Override
                         public void onResponse(Call<Boolean> call, Response<Boolean> response) {
@@ -97,7 +98,7 @@ public class MainActivity extends AppCompatActivity {
                             }else{
                                 intent = new Intent(getApplicationContext(), LocationSettingActivity.class);
                                 intent.putExtra("appointmentId", appointmentList.get(position).getId());
-                                intent.putExtra("participantName", appointmentList.get(position).getName());
+                                intent.putExtra("participantName", appointmentList.get(position).getParticipantName());
                             }
                             startActivity(intent);
                         }

--- a/frontend/app/src/main/java/com/example/wwmeet_android/appointment/create/SetVoteDeadlineActivity.java
+++ b/frontend/app/src/main/java/com/example/wwmeet_android/appointment/create/SetVoteDeadlineActivity.java
@@ -113,13 +113,9 @@ public class SetVoteDeadlineActivity extends AppCompatActivity {
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }
+                            return;
                         }
                         Long appointmentId = response.body();
-
-                        // local db에 저장
-                        MyAppointment myAppointment = new MyAppointment(appointmentId, appointment.getParticipantName());
-                        LocalDatabaseUtil database = new LocalDatabaseUtil(getApplicationContext());
-                        database.saveMyAppointment(myAppointment);
 
                         Intent intent = new Intent(getApplicationContext(), AppointmentInfoBeforeActivity.class);
                         intent.putExtra("appointmentId", appointmentId);

--- a/frontend/app/src/main/java/com/example/wwmeet_android/dto/FindAppointmentListResponse.java
+++ b/frontend/app/src/main/java/com/example/wwmeet_android/dto/FindAppointmentListResponse.java
@@ -11,7 +11,6 @@ public class FindAppointmentListResponse {
     private boolean voteFinish;
     private String appointmentDate;
 
-    @Expose(serialize = false, deserialize = false)
     private String participantName;
 
 
@@ -48,14 +47,6 @@ public class FindAppointmentListResponse {
         this.voteDeadline = voteDeadline;
     }
 
-    public void setName(String name){
-        this.participantName = name;
-    }
-
-    public String getName(){
-        return participantName;
-    }
-
     public String getAppointmentDate(){
         return appointmentDate;
     }
@@ -70,5 +61,13 @@ public class FindAppointmentListResponse {
 
     public void setVoteFinish(boolean voteFinish) {
         this.voteFinish = voteFinish;
+    }
+
+    public String getParticipantName() {
+        return participantName;
+    }
+
+    public void setParticipantName(String participantName) {
+        this.participantName = participantName;
     }
 }

--- a/frontend/app/src/main/java/com/example/wwmeet_android/network/RetrofitService.java
+++ b/frontend/app/src/main/java/com/example/wwmeet_android/network/RetrofitService.java
@@ -38,8 +38,8 @@ public interface RetrofitService {
     @POST("/api/appointments")
     Call<Long> saveAppointment(@Body SaveAppointmentRequest saveAppointmentRequest);
 
-    @GET("/api/appointments/{id}/{name}/vote-status")
-    Call<Boolean> getVoteStatusOfParticipant(@Path("id") Long id, @Path("name") String name);
+    @GET("/api/appointments/{id}/{participantName}/vote-status")
+    Call<Boolean> getVoteStatusOfParticipant(@Path("id") Long id, @Path("participantName") String participantName);
 
     @GET("/api/appointments/code")
     Call<Long> findAppointmentByCode(@Query("code") String code);


### PR DESCRIPTION
## 목적
약속 조회 로직에 member를 이용하도록 수정하고 오류가 나는 것을 고침

## 변경점
약속 전체 조회 시 member를 이용
단건 조회 시 participantName을 전체 조회 시 바로 받도록 변경

## 특이사항

## 이슈 #165 
